### PR TITLE
(#10) Override [Gateway::getDefaultHttpClient] method and set a timeout of 180 seconds.

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -145,4 +145,20 @@ class Gateway extends AbstractGateway implements GatewayInterface
     {
         return $this->setApiRestrictKey($value);
     }
+
+    /**
+     * Configure the default client with custom values.
+     *
+     * CURLOPT_CONNECTTIMEOUT: is the maximum amount of time in seconds
+     *                         that is allowed to make the connection to the server.
+     */
+    protected function getDefaultHttpClient()
+    {
+        $client = parent::getDefaultHttpClient();
+        $client->setConfig(array(
+            'curl.options' => array(CURLOPT_CONNECTTIMEOUT => 180),
+        ));
+
+        return $client;
+    }
 }


### PR DESCRIPTION
The default 60 seconds ttl appears to be too short for EPN. will try 180 instead.