### PR TITLE
(Closes #12) Change connection window timeout

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -149,15 +149,21 @@ class Gateway extends AbstractGateway implements GatewayInterface
     /**
      * Configure the default client with custom values.
      *
+     * CURLOPT_TIMEOUT:        is the maximum amount of time in seconds
+     *                         that cURL is allowed to use for connection, including connection
+     *                         and transfer
      * CURLOPT_CONNECTTIMEOUT: is the maximum amount of time in seconds
      *                         that is allowed to make the connection to the server.
      */
     protected function getDefaultHttpClient()
     {
         $client = parent::getDefaultHttpClient();
-        $client->setConfig(array(
-            'curl.options' => array(CURLOPT_CONNECTTIMEOUT => 180),
-        ));
+        $client->setConfig([
+            'curl.options' => [
+                CURLOPT_TIMEOUT        => 360,
+                CURLOPT_CONNECTTIMEOUT => 180,
+            ],
+        ]);
 
         return $client;
     }


### PR DESCRIPTION
The connection may timeout as well as the connection negotiation, so the former should be longer than the later.

Is expected to fix the following exception plaguing PMG:
```
Guzzle\Http\Exception\CurlException thrown with message "[curl] 7: Failed to connect to www.eprocessingnetwork.com port 443: Connection timed out [url] https://www.eprocessingnetwork.com/cgi-bin/tdbe/transact.pl"
```